### PR TITLE
ENGOPS-6641: Add initial additional-information optional parameter

### DIFF
--- a/.github/workflows/generate-fixtures.yml
+++ b/.github/workflows/generate-fixtures.yml
@@ -17,6 +17,7 @@ jobs:
           basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
           hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
           this-job-name: my dummy job
+          additional-information: my dummy additional information
 
       - name: Dummy step 2
         id: dummy-step-2
@@ -41,6 +42,7 @@ jobs:
           basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
           hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
           this-job-name: my dummy job
+          additional-information: my dummy additional information
 
   generate-fixtures:
     name: generate-fixtures-name-${{ matrix.name }}
@@ -67,6 +69,7 @@ jobs:
           basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
           hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
           this-job-name: generate-fixtures-name-${{ matrix.name }}
+          additional-information: additional information for generate-fixtures-name-${{ matrix.name }}
 
       - name: Create required directories
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,11 @@ inputs:
     description: |
       Json test result file to attach to the output logs, available types: go
       example: {"testType":"go","filePath":"./go_test_results_path.json"}
+  additional-information:
+    required: false
+    description: |
+      An optional field if you need to pass an additional string 
+      that can help with filter expressions
 
 runs:
   using: "node16"

--- a/dist/index.js
+++ b/dist/index.js
@@ -11744,6 +11744,8 @@ function createLokiLogValueFromTestResult(testResult, context2) {
   testResult.jobName = context2.jobRun.jobName;
   testResult.repo = context2.event.repo.repo;
   testResult.jobRunId = context2.jobRun.id;
+  testResult.statusInt = testResult.status == "pass" ? 1 : 0;
+  testResult.sha = context2.event.sha;
   const log = JSON.stringify(testResult);
   const secondInNanoSeconds = BigInt(1e9);
   const ts = BigInt(context2.jobRun.estimatedEndedAtUnixSeconds) * secondInNanoSeconds;

--- a/src/context.ts
+++ b/src/context.ts
@@ -22,6 +22,7 @@ export async function fetchContext(
   githubClient: types.Octokit,
   rawGithubContext: typeof RawGithubContext,
   contextOverrides?: types.ContextOverrides,
+  additionalInformation? : string,
 ): Promise<types.Context> {
   const githubContext = getGithubContext(rawGithubContext, contextOverrides)
   const jobRunContext = await fetchJobRunContext(
@@ -53,6 +54,7 @@ export async function fetchContext(
     event: rest,
     workflowRun: mergedWorkflowRunContext,
     jobRun: mergedJobRunContext,
+    ...(additionalInformation && { additionalInformation })
   }
 }
 

--- a/src/context.types.ts
+++ b/src/context.types.ts
@@ -44,6 +44,10 @@ export interface Context {
    * The current job run context
    */
   jobRun: JobRunContext & Pick<GithubContext, GithubContextJobRunPropertyKeys>
+  /**
+   * Optional additional information provided when pushing metrics
+   */
+  additionalInformation?: string
 }
 
 type JobRun = Awaited<

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,9 @@ export async function main() {
     const contextOverrides: contextTypes.ContextOverrides = {
       jobName: getTypedInput('this-job-name') || undefined,
     }
+    const additionalInformation = getTypedInput('additional-information') || undefined
 
-    const context = await fetchContext(githubClient, rawContext, contextOverrides)
+    const context = await fetchContext(githubClient, rawContext, contextOverrides, additionalInformation)
     core.endGroup()
 
     core.startGroup('Load test results into context if present')
@@ -99,6 +100,7 @@ function getTypedInput(
       githubToken: never
       thisJobName: never
       testResultsFile: never
+      additionalInformation: never
     }
   >,
   required = true,

--- a/test/integration/loki.integration.test.ts
+++ b/test/integration/loki.integration.test.ts
@@ -24,6 +24,12 @@ function generateMockContexts(amount = 100, dateRangeInDays = 1) {
   ] as const
   const fakeCDJobNameArr = ["release", "create-tags", "push-image"] as const
   const fakeWorkflowNameArr = ["CI", "CD"] as const
+  const fakeAdditionalInformation = [
+    "kusama-mainnet-moonriver - 45 - kill:proxies:safe",
+    "mainnet - 1124 - monitoring:setWatchList:safe",
+    "mainnet - 1123 - ownership:accept:offchain:safe",
+    "mainnet - 1122 - raise:flags:safe",
+  ] as const
 
   return Array(amount)
     .fill(null)
@@ -96,6 +102,11 @@ function generateMockContexts(amount = 100, dateRangeInDays = 1) {
           workflowName,
           workflowUrl: faker.internet.url(),
         },
+      }
+
+      const includeAdditionalInformation = faker.datatype.boolean()
+      if (includeAdditionalInformation) {
+        ctx["additionalInformation"] = faker.helpers.arrayElement(fakeAdditionalInformation)
       }
 
       return ctx

--- a/test/integration/loki.integration.test.ts
+++ b/test/integration/loki.integration.test.ts
@@ -24,12 +24,6 @@ function generateMockContexts(amount = 100, dateRangeInDays = 1) {
   ] as const
   const fakeCDJobNameArr = ["release", "create-tags", "push-image"] as const
   const fakeWorkflowNameArr = ["CI", "CD"] as const
-  const fakeAdditionalInformation = [
-    "kusama-mainnet-moonriver - 45 - kill:proxies:safe",
-    "mainnet - 1124 - monitoring:setWatchList:safe",
-    "mainnet - 1123 - ownership:accept:offchain:safe",
-    "mainnet - 1122 - raise:flags:safe",
-  ] as const
 
   return Array(amount)
     .fill(null)
@@ -106,7 +100,7 @@ function generateMockContexts(amount = 100, dateRangeInDays = 1) {
 
       const includeAdditionalInformation = faker.datatype.boolean()
       if (includeAdditionalInformation) {
-        ctx["additionalInformation"] = faker.helpers.arrayElement(fakeAdditionalInformation)
+        ctx["additionalInformation"] = faker.lorem.lines(1)
       }
 
       return ctx


### PR DESCRIPTION
We (on the EngOps side) want to have some form of dynamic naming for the job name that comes from the pull request title. I tried using `this-job-name`, but then looking in the code and the README, this-job-name is the name of the running workflow. It can be changed only as a matrix. 

With an optional property, we want to provide a little bit more information about the running workflow.

For specific gauntlet commands (executed through clops workflow), it creates a PR that needs to be reviewed and merged. For metrics, we are only interested in opened and merged pull requests. The title of the pull request comes in the form of `network-name - number - command`. But, we will only send `network-name` and `command` in the payload. With this additional information in logs, we can apply filtering and create count metrics about opened and closed PRs for commands we are interested in.

If there is another way to do that, please let me know, and we can discuss what needs to be changed.