### PR TITLE
chore: grafana internal credentials

### DIFF
--- a/.github/workflows/sync-github-push-gha-metrics-source.yml
+++ b/.github/workflows/sync-github-push-gha-metrics-source.yml
@@ -30,10 +30,11 @@ jobs:
     steps:
       - name: Collect Metrics
         id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@v2
+        uses: smartcontractkit/push-gha-metrics-action@v2.1.0
         with:
-          basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID}}
           this-job-name: Update Version
         continue-on-error: true
 
@@ -65,10 +66,11 @@ jobs:
     steps:
       - name: Collect Metrics
         id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@v2
+        uses: smartcontractkit/push-gha-metrics-action@v2.1.0
         with:
-          basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID}}
           this-job-name: Update Version
         continue-on-error: true
 

--- a/README.md
+++ b/README.md
@@ -200,8 +200,9 @@ jobs:
 
       - uses: ./.github/actions/push-metrics/
         with:
-          basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID}}
           this-job-name: B
 
       - run: echo "test test test"
@@ -214,8 +215,9 @@ jobs:
 
       - uses: ./.github/actions/push-metrics/
         with:
-          basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID}}
           this-job-name: C
 
       - run: echo "test test test"


### PR DESCRIPTION
Migrate all grafana credentials to internal.

Post-merge:
- [ ] Delete `GRAFANA_CLOUD_*` repo secrets

---

RE-2240